### PR TITLE
pytest: ignore deprecation warning for collections in idalink

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections\.abc' is deprecated:DeprecationWarning


### PR DESCRIPTION
The deprecation warning is for python 3.3 onwards, but idalink
currently only supports python 2 anyways, as we don't have
IDA 7.4+ to adapt it to python3.